### PR TITLE
Improve compatibility with RimWorld 1.6, migrate to SDK-style project, and check for reachability first when computing for path cost to settlement

### DIFF
--- a/About/About.xml
+++ b/About/About.xml
@@ -3,7 +3,7 @@
   <name>Pawn Editor</name>
   <author>legodude17, ISOREX</author>
   <supportedVersions>
-    <li>1.5</li>
+    <li>1.6</li>
   </supportedVersions>
   <packageId>ISOREX.PawnEditor</packageId>
   <modVersion>1.1.1</modVersion>

--- a/Languages/English/Keyed/UI.xml
+++ b/Languages/English/Keyed/UI.xml
@@ -199,6 +199,7 @@
     <PawnEditor.Settlements>Settlements</PawnEditor.Settlements>
     <PawnEditor.DistanceFromColony>Distance from colony</PawnEditor.DistanceFromColony>
     <PawnEditor.DistanceFromColony.Calculate>Calculate distance from colony</PawnEditor.DistanceFromColony.Calculate>
+    <PawnEditor.DistanceFromColony.NoPath>No path</PawnEditor.DistanceFromColony.NoPath>
     <PawnEditor.TraitDisallowedByKind>Trait {0} is not allowed on {1}.</PawnEditor.TraitDisallowedByKind>
     <PawnEditor.TraitConflicts>Trait {0} conflicts with trait {1}.</PawnEditor.TraitConflicts>
     <PawnEditor.TraitWorkDisabled>{0} can't do {1}, which is required by {2}.</PawnEditor.TraitWorkDisabled>

--- a/Source/PawnEditor/Defs/Defs.cs
+++ b/Source/PawnEditor/Defs/Defs.cs
@@ -251,6 +251,6 @@ public class WidgetWorker_Blank : WidgetWorker<Pawn>
 {
     public override void Draw(Rect inRect, Pawn pawn)
     {
-        Widgets.DrawBoxSolid(inRect, pawn.story?.favoriteColor ?? Color.cyan);
+        Widgets.DrawBoxSolid(inRect, pawn.story?.favoriteColor.color ?? Color.cyan);
     }
 }

--- a/Source/PawnEditor/Dialogs/Dialog_AppearanceEditor.cs
+++ b/Source/PawnEditor/Dialogs/Dialog_AppearanceEditor.cs
@@ -424,18 +424,25 @@ public class Dialog_AppearanceEditor : Window
             var rect = new Rect(i % itemsPerRow * itemSize, Mathf.Floor((float)i / itemsPerRow) * itemSize, itemSize, itemSize).ContractedBy(2);
             bool enabled = GeneIsAllowed(option);
             Widgets.DrawHighlight(rect);
-            if (pawn.genes.HasGene(option)) Widgets.DrawBox(rect);
+            if (pawn.genes.HasActiveGene(option))
+            {
+                Widgets.DrawBox(rect);
+            }
             if (enabled && Widgets.ButtonInvisible(rect))
             {
-                if (pawn.genes.HasGene(option))
+                if (pawn.genes.HasActiveGene(option))
+                {
                     pawn.genes.RemoveGene(pawn.genes.GetGene(option));
+                }
                 else
+                {
                     foreach (var geneDef in options)
                     {
                         if (pawn.genes.GetGene(geneDef) is { } gene) pawn.genes.RemoveGene(gene);
 
                         pawn.genes.AddGene(option, false);
                     }
+                }
             }
 
             GUI.color = enabled ? Color.white : Color.gray;
@@ -716,7 +723,7 @@ public class Dialog_AppearanceEditor : Window
 
             foreach (GeneDef requiredGene in def.requiredGenes)
             {
-                if (!pawn.genes.HasGene(requiredGene))
+                if (!pawn.genes.HasActiveGene(requiredGene))
                 {
                     return false;
                 }

--- a/Source/PawnEditor/Dialogs/EditMenus/Dialog_EditThing.cs
+++ b/Source/PawnEditor/Dialogs/EditMenus/Dialog_EditThing.cs
@@ -65,10 +65,14 @@ public class Dialog_EditThing : Dialog_EditItem<Thing>
             var defaultColor = apparel2.Stuff != null ? apparel2.Stuff.stuffProps.color : apparel2.def.colorGenerator?.NewRandomizedColor() ?? Color.white;
             if (Widgets.ButtonText(widgetRect, "PawnEditor.PickColor".Translate()))
             {
-                var specialColors = new Dictionary<string, Color>();
-                specialColors.Add("Default", defaultColor);
-                if (Pawn.story.favoriteColor.HasValue)
-                    specialColors.Add("Favorite", Pawn.story.favoriteColor.Value);
+                var specialColors = new Dictionary<string, Color>
+                {
+                    { "Default", defaultColor }
+                };
+                if (Pawn.story.favoriteColor != null)
+                {
+                    specialColors.Add("Favorite", Pawn.story.favoriteColor.color);
+                }
 
                 Find.WindowStack.Add(new Dialog_ColorPicker(color => apparel2.SetColor(color),
                     DefDatabase<ColorDef>.AllDefs.Select(cd => cd.color).ToList(), curColor, specialColors));

--- a/Source/PawnEditor/Dialogs/ListingMenus/ListingMenu_Thought.cs
+++ b/Source/PawnEditor/Dialogs/ListingMenus/ListingMenu_Thought.cs
@@ -13,7 +13,7 @@ public class ListingMenu_Thoughts : ListingMenu<ThoughtDef>
 {
     private static readonly List<ThoughtDef> moodMemoryDefs;
     private static readonly List<ThoughtDef> opinionMemoryDefs;
-    private static IntRange maxMoodOffset = IntRange.one;
+    private static IntRange maxMoodOffset = IntRange.One;
 
     private static readonly HashSet<string> extraNeedsOtherPawn = new()
     {
@@ -159,7 +159,7 @@ public class ListingMenu_Thoughts : ListingMenu<ThoughtDef>
             new Filter_ModSource<ThoughtDef>(),
             new Filter_IntRange<ThoughtDef>("PawnEditor.MoodOffset".Translate(), maxMoodOffset, def =>
             {
-                var range = IntRange.zero;
+                var range = IntRange.Zero;
 
                 foreach (var thoughtStage in def.stages)
                 {

--- a/Source/PawnEditor/PawnEditor.csproj
+++ b/Source/PawnEditor/PawnEditor.csproj
@@ -1,48 +1,28 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{6AA80DAE-058C-4E97-8F1B-D6C344C53987}</ProjectGuid>
+    <TargetFramework>net472</TargetFramework>
     <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>PawnEditor</RootNamespace>
-    <AssemblyName>PawnEditor</AssemblyName>
-    <TargetFrameworkVersion>v4.7.2</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <Deterministic>true</Deterministic>
+    <AssemblyTitle>PawnEditor</AssemblyTitle>
+	  <Description>A mod for RimWorld that allows you to edit pawns.</Description>
+    <Company>isorex</Company>
+    <Product>PawnEditor</Product>
+    <AssemblyVersion>1.0.9</AssemblyVersion>
+    <FileVersion>1.0.9</FileVersion>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>portable</DebugType>
-    <Optimize>false</Optimize>
     <OutputPath>..\..\Assemblies</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugSymbols>false</DebugSymbols>
     <DebugType>none</DebugType>
-    <Optimize>true</Optimize>
     <OutputPath>..\..\Assemblies</OutputPath>
-    <DefineConstants>
-    </DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <DefineConstants></DefineConstants>
     <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Krafs.Publicizer">
@@ -61,85 +41,6 @@
     <Publicize Include="Assembly-CSharp" />
   </ItemGroup>
   <ItemGroup>
-    <Compile Include="Defs\Defs.cs" />
-    <Compile Include="Defs\KeyBindDefOf.cs" />
-    <Compile Include="Dialogs\Dialog_AppearanceEditor.cs" />
-    <Compile Include="Dialogs\Dialog_ColorPicker.cs" />
-    <Compile Include="Dialogs\Dialog_Confirm.cs" />
-    <Compile Include="Dialogs\EditMenus\Dialog_EditHediff.cs" />
-    <Compile Include="Dialogs\EditMenus\Dialog_EditItem.cs" />
-    <Compile Include="Dialogs\Dialog_PawnEditor.cs" />
-    <Compile Include="Dialogs\Dialog_PawnEditorFiles.cs" />
-    <Compile Include="Dialogs\EditMenus\Dialog_EditRelation.cs" />
-    <Compile Include="Dialogs\EditMenus\Dialog_EditThing.cs" />
-    <Compile Include="Dialogs\EditMenus\Dialog_EditThought.cs" />
-    <Compile Include="Dialogs\ListingMenus\Filters\Filter.cs" />
-    <Compile Include="Dialogs\ListingMenus\Filters\Filter_Dropdown.cs" />
-    <Compile Include="Dialogs\ListingMenus\Filters\Filter_IntRange.cs" />
-    <Compile Include="Dialogs\ListingMenus\Filters\Filter_ModSource.cs" />
-    <Compile Include="Dialogs\ListingMenus\Filters\Filter_Toggle.cs" />
-    <Compile Include="Dialogs\ListingMenus\ListingMenu.cs" />
-    <Compile Include="Dialogs\ListingMenus\ListingMenu_Abilities.cs" />
-    <Compile Include="Dialogs\ListingMenus\ListingMenu_Backstories.cs" />
-    <Compile Include="Dialogs\ListingMenus\ListingMenu_Hediffs.cs" />
-    <Compile Include="Dialogs\ListingMenus\ListingMenu_Items.cs" />
-    <Compile Include="Dialogs\ListingMenus\ListingMenu_PawnKindDef.cs" />
-    <Compile Include="Dialogs\ListingMenus\ListingMenu_Pawns.cs" />
-    <Compile Include="Dialogs\ListingMenus\ListingMenu_Relations.cs" />
-    <Compile Include="Dialogs\ListingMenus\ListingMenu_Thought.cs" />
-    <Compile Include="Dialogs\ListingMenus\ListingMenu_Trait.cs" />
-    <Compile Include="ModCompat\FacialAnimCompat.cs" />
-    <Compile Include="ModCompat\HARCompat.cs" />
-    <Compile Include="ModCompat\VSECompat.cs" />
-    <Compile Include="Tabs\AnimalMech\TabWorker_Bio_AnimalMech.cs" />
-    <Compile Include="Tabs\Humanlike\Bio\BasicInfo.cs" />
-    <Compile Include="Tabs\Humanlike\TabWorker_Gear.cs" />
-    <Compile Include="Tabs\Humanlike\Bio\Groups.cs" />
-    <Compile Include="Tabs\Humanlike\Bio\LeftList.cs" />
-    <Compile Include="Tabs\Humanlike\Bio\Randomization.cs" />
-    <Compile Include="Tabs\Humanlike\Bio\TabWorker_Bio_Humanlike.cs" />
-    <Compile Include="Tabs\Humanlike\Bio\TopRightButtons.cs" />
-    <Compile Include="Tabs\Humanlike\TabWorker_Needs.cs" />
-    <Compile Include="Tabs\Humanlike\TabWorker_Social.cs" />
-    <Compile Include="Tabs\NPCFaction\TabWorker_FactionSettlements.cs" />
-    <Compile Include="Tabs\NPCFaction\TabWorker_NPCFactionOverview.cs" />
-    <Compile Include="Tabs\PlayerFaction\TabWorker_AnimalMech.cs" />
-    <Compile Include="Tabs\PlayerFaction\TabWorker_EquipmentLoot.cs" />
-    <Compile Include="Tabs\PlayerFaction\TabWorker_PlayerFactionOverview.cs" />
-    <Compile Include="Tabs\TabWorker_FactionOverview.cs" />
-    <Compile Include="Tabs\TabWorker_Health.cs" />
-    <Compile Include="UI\LeftPanel.cs" />
-    <Compile Include="UI\PawnCategory.cs" />
-    <Compile Include="Defs\PawnEditorDefOf.cs" />
-    <Compile Include="PawnEditorMod.cs" />
-    <Compile Include="UI\PawnEditorUI.cs" />
-    <Compile Include="UI\PawnList.cs" />
-    <Compile Include="UI\UITable.cs" />
-    <Compile Include="UI\Widgets.cs" />
-    <Compile Include="Utils\AddResult.cs" />
-    <Compile Include="Utils\CopyPaste.cs" />
-    <Compile Include="Utils\EditUtility.cs" />
-    <Compile Include="Utils\Listing_Thing.cs" />
-    <Compile Include="Utils\Listing_TreeThing.cs" />
-    <Compile Include="Utils\ColonyInventory.cs" />
-    <Compile Include="Utils\PawnEditor-PawnsFinder.cs" />
-    <Compile Include="Utils\PawnLister.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="SaveLoad\ReferenceManager.cs" />
-    <Compile Include="SaveLoad\SaveLoadItem.cs" />
-    <Compile Include="SaveLoad\SaveLoadPatches.cs" />
-    <Compile Include="SaveLoad\SaveLoadUtility.cs" />
-    <Compile Include="Utils\PointsSystem.cs" />
-    <Compile Include="Utils\RelationUtilities.cs" />
-    <Compile Include="Utils\RimUI\Listing_Horizontal.cs" />
-    <Compile Include="Utils\RimUI\UIComponents.cs" />
-    <Compile Include="Utils\StartingThingsManager.cs" />
-    <Compile Include="UI\TexPawnEditor.cs" />
-    <Compile Include="Utils\UIUtility.cs" />
-    <Compile Include="Utils\Utilities.cs" />
-  </ItemGroup>
-  <ItemGroup>
     <Content Include="Utils\RimUI\ReadMe.txt" />
   </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
 </Project>

--- a/Source/PawnEditor/PawnEditor.csproj
+++ b/Source/PawnEditor/PawnEditor.csproj
@@ -31,7 +31,7 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Krafs.Rimworld.Ref">
-      <Version>1.5.4297</Version>
+      <Version>1.6.4489-beta</Version>
     </PackageReference>
     <PackageReference Include="Lib.Harmony">
       <Version>2.3.3</Version>

--- a/Source/PawnEditor/Properties/AssemblyInfo.cs
+++ b/Source/PawnEditor/Properties/AssemblyInfo.cs
@@ -4,11 +4,6 @@ using System.Runtime.InteropServices;
 // General Information about an assembly is controlled through the following
 // set of attributes. Change these attribute values to modify the information
 // associated with an assembly.
-[assembly: AssemblyTitle("PawnEditor")]
-[assembly: AssemblyDescription("A mod for RimWorld that allows you to edit pawns.")]
-[assembly: AssemblyConfiguration("")]
-[assembly: AssemblyCompany("isorex")]
-[assembly: AssemblyProduct("PawnEditor")]
 [assembly: AssemblyCopyright("Copyright ©  2024")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
@@ -20,16 +15,3 @@ using System.Runtime.InteropServices;
 
 // The following GUID is for the ID of the typelib if this project is exposed to COM
 [assembly: Guid("6aa80dae-058c-4e97-8f1b-d6c344c53987")]
-
-// Version information for an assembly consists of the following four values:
-//
-//      Major Version
-//      Minor Version
-//      Build Number
-//      Revision
-//
-// You can specify all the values or you can default the Build and Revision Numbers
-// by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.9")]
-[assembly: AssemblyFileVersion("1.0.9")]

--- a/Source/PawnEditor/Tabs/Humanlike/Bio/LeftList.cs
+++ b/Source/PawnEditor/Tabs/Humanlike/Bio/LeftList.cs
@@ -145,11 +145,11 @@ public partial class TabWorker_Bio_Humanlike
         colorRect.xMin += 6f;
         string label = "PawnEditor.FavColor".Translate();
         using (new TextBlock(TextAnchor.MiddleLeft)) Widgets.Label(colorRect.TakeLeftPart(Text.CalcSize(label).x + 4), label);
-        Widgets.DrawBoxSolid(colorRect.TakeRightPart(30).ContractedBy(2.5f), pawn.story.favoriteColor ?? Color.white);
+        Widgets.DrawBoxSolid(colorRect.TakeRightPart(30).ContractedBy(2.5f), pawn.story.favoriteColor?.color ?? Color.white);
         if (Widgets.ButtonText(colorRect, "PawnEditor.PickColor".Translate()))
         {
-            var currentColor = pawn.story.favoriteColor ?? Color.white;
-            Find.WindowStack.Add(new Dialog_ColorPicker(color => pawn.story.favoriteColor = color, DefDatabase<ColorDef>.AllDefs
+            var currentColor = pawn.story.favoriteColor?.color ?? Color.white;
+            Find.WindowStack.Add(new Dialog_ColorPicker(color => pawn.story.favoriteColor.color = color, DefDatabase<ColorDef>.AllDefs
                    .Select(cd => cd.color)
                    .ToList(),
                 currentColor));

--- a/Source/PawnEditor/Tabs/Humanlike/TabWorker_Gear.cs
+++ b/Source/PawnEditor/Tabs/Humanlike/TabWorker_Gear.cs
@@ -216,9 +216,13 @@ public class TabWorker_Gear : TabWorker<Pawn>
                             if (a.TryGetComp<CompColorable>() != null)
                             {
                                 if (pawn.story.favoriteColor != null)
-                                    a.SetColor((Color)pawn.story.favoriteColor);
+                                {
+                                    a.SetColor(pawn.story.favoriteColor.color);
+                                }
                                 else
+                                {
                                     Messages.Message("No favourite color found for pawn", MessageTypeDefOf.RejectInput);
+                                }
                             }
                         }
                     );

--- a/Source/PawnEditor/Tabs/Humanlike/TabWorker_Social.cs
+++ b/Source/PawnEditor/Tabs/Humanlike/TabWorker_Social.cs
@@ -45,7 +45,7 @@ public class TabWorker_Social : TabWorker_Table<Pawn>
                         ? Find.GameInitData.startingAndOptionalPawns
                         : pawn.MapHeld?.mapPawns.AllPawns
                        ?? pawn.GetCaravan()?.PawnsListForReading ?? PawnsFinder
-                             .AllCaravansAndTravelingTransportPods_Alive;
+                             .AllCaravansAndTravellingTransporters_Alive;
 
                     Find.WindowStack.Add(new FloatMenu(pawns.Where(p => p.RaceProps.Humanlike)
                        .Select(p => new FloatMenuOption(p.LabelCap, () =>

--- a/Source/PawnEditor/Tabs/NPCFaction/TabWorker_FactionSettlements.cs
+++ b/Source/PawnEditor/Tabs/NPCFaction/TabWorker_FactionSettlements.cs
@@ -65,9 +65,11 @@ public class TabWorker_FactionSettlements : TabWorker<Faction>
             };
             
             foreach (var settlement in Find.WorldObjects.Settlements.Where(s => s.Faction == faction))
-                using (var worldPath = Find.WorldPathFinder.FindPath(startingTile, settlement.Tile, null))
-                    distances.Add(settlement, CaravanArrivalTimeEstimator.EstimatedTicksToArrive(startingTile, settlement.Tile, worldPath, 0f,
-                        CaravanTicksPerMoveUtility.GetTicksPerMove(caravanInfo), Find.TickManager.TicksAbs));
+            {
+                using var worldPath = startingTile.Layer.pather.FindPath(startingTile, settlement.Tile, null);
+                distances.Add(settlement, CaravanArrivalTimeEstimator.EstimatedTicksToArrive(startingTile, settlement.Tile, worldPath, 0f,
+                    CaravanTicksPerMoveUtility.GetTicksPerMove(caravanInfo), Find.TickManager.TicksAbs));
+            }
            
             settlementTable.ClearCache();
         }

--- a/Source/PawnEditor/Tabs/PlayerFaction/TabWorker_AnimalMech.cs
+++ b/Source/PawnEditor/Tabs/PlayerFaction/TabWorker_AnimalMech.cs
@@ -77,7 +77,7 @@ public class TabWorker_AnimalMech : TabWorker<Faction>
             animalCount++;
             var items = new List<UITable<Faction>.Row.Item>
             {
-                new(Widgets.GetIconFor(pawn, Vector2.one, null, false, out _, out _, out _, out _)),
+                new(Widgets.GetIconFor(pawn, Vector2.one, null, false, out _, out _, out _, out _, out _)),
                 new(pawn.Name.ToStringShort, pawn.Name.ToStringShort.ToCharArray()[0], TextAnchor.MiddleLeft),
                 new(pawn.ageTracker.CurLifeStageRace.GetIcon(pawn), pawn.ageTracker.CurLifeStageIndex),
                 new(pawn.gender.GetIcon(), (int)pawn.gender),
@@ -142,7 +142,7 @@ public class TabWorker_AnimalMech : TabWorker<Faction>
             mechCount++;
             var items = new List<UITable<Faction>.Row.Item>
             {
-                new(Widgets.GetIconFor(pawn, Vector2.one, null, false, out _, out _, out _, out _)),
+                new(Widgets.GetIconFor(pawn, Vector2.one, null, false, out _, out _, out _, out _, out _)),
                 new(pawn.Name.ToStringShort, pawn.Name.ToStringShort.ToCharArray()[0], TextAnchor.MiddleLeft),
                 new(pawn.MarketValue.ToStringMoney(), (int)pawn.MarketValue),
                 new(pawn.GetOverseer()?.Name?.ToStringShort ?? "OverseerNone".Translate(), () =>

--- a/Source/PawnEditor/Tabs/PlayerFaction/TabWorker_EquipmentLoot.cs
+++ b/Source/PawnEditor/Tabs/PlayerFaction/TabWorker_EquipmentLoot.cs
@@ -51,7 +51,7 @@ public class TabWorker_EquipmentLoot : TabWorker<Faction>
             var thing = things[i];
             var items = new List<UITable<Faction>.Row.Item>
             {
-                new(thing.LabelCapNoCount, Widgets.GetIconFor(thing, new(25, 25), Rot4.South, false, out _, out _, out _, out _), i),
+                new(thing.LabelCapNoCount, Widgets.GetIconFor(thing, new(25, 25), Rot4.South, false, out _, out _, out _, out _, out _), i),
                 new(thing.GetStatValue(StatDefOf.Mass).ToStringMass(), (int)thing.GetStatValue(StatDefOf.Mass)),
                 new(((float)thing.HitPoints / thing.MaxHitPoints).ToStringPercent(), thing.HitPoints / thing.MaxHitPoints),
                 new(thing.MarketValue.ToStringMoney(), (int)thing.MarketValue),

--- a/Source/PawnEditor/Tabs/PlayerFaction/TabWorker_PlayerFactionOverview.cs
+++ b/Source/PawnEditor/Tabs/PlayerFaction/TabWorker_PlayerFactionOverview.cs
@@ -76,7 +76,7 @@ public class TabWorker_PlayerFactionOverview : TabWorker_FactionOverview
         var map = Find.CurrentMap ?? Find.AnyPlayerHomeMap;
         var pawns = PawnEditor.Pregame
             ? Find.GameInitData.startingAndOptionalPawns
-            : map?.mapPawns?.PawnsInFaction(faction) ?? PawnsFinder.AllMapsCaravansAndTravelingTransportPods_Alive_FreeColonists;
+            : map?.mapPawns?.PawnsInFaction(faction) ?? PawnsFinder.AllMapsCaravansAndTravellingTransporters_Alive_FreeColonists;
         pawns.RemoveAll(pawn => pawn.skills == null);
         if (pawns.NullOrEmpty()) return null;
         var pawn = pawns[0];


### PR DESCRIPTION
**Summary**
- Updated for RimWorld 1.6 compatibility.
- Adjusted references and APIs as needed for 1.6 (currently targets beta/unstable)
- Migrated to SDK-style `.csproj` (improves buildability on VS Code and Linux).
- Added an early reachability check when calculating path cost to settlements, avoids unnecessary work and errors when tile isn't reachable on land.

Feel free to adjust as you will.